### PR TITLE
fix grammer in prereq gcp doc

### DIFF
--- a/docs/howto/operator/gcp/_partials/prerequisite_tasks.rst
+++ b/docs/howto/operator/gcp/_partials/prerequisite_tasks.rst
@@ -19,15 +19,15 @@
 
 To use these operators, you must do a few things:
 
-  * Select or create a Cloud Platform project using `Cloud Console <https://console.cloud.google.com/project>`__.
-  * Enable billing for your project, as described in `Google Cloud documentation <https://cloud.google.com/billing/docs/how-to/modify-project#enable_billing_for_a_project>`__.
-  * Enable API, as described in `Cloud Console documentation <https://cloud.google.com/apis/docs/enable-disable-apis>`__.
+  * Select or create a Cloud Platform project using the `Cloud Console <https://console.cloud.google.com/project>`__.
+  * Enable billing for your project, as described in the `Google Cloud documentation <https://cloud.google.com/billing/docs/how-to/modify-project#enable_billing_for_a_project>`__.
+  * Enable the API, as described in the `Cloud Console documentation <https://cloud.google.com/apis/docs/enable-disable-apis>`__.
   * Install API libraries via **pip**.
 
     .. code-block:: bash
 
       pip install 'apache-airflow[google]'
 
-    Detailed information is available :doc:`../../../../installation`
+    Detailed information is available at :doc:`../../../../installation`.
 
-  * :doc:`Setup Connection <../../connection/gcp>`.
+  * :doc:`Setup a GCP Connection <../../connection/gcp>`.

--- a/docs/howto/operator/gcp/_partials/prerequisite_tasks.rst
+++ b/docs/howto/operator/gcp/_partials/prerequisite_tasks.rst
@@ -28,6 +28,6 @@ To use these operators, you must do a few things:
 
       pip install 'apache-airflow[google]'
 
-    Detailed information is available at :doc:`../../../../installation`.
+    Detailed information is available for :doc:`../../../../installation`.
 
   * :doc:`Setup a GCP Connection <../../connection/gcp>`.


### PR DESCRIPTION
Fix grammer in prerequisite_tasks.rst for GCP operator documentation.
---
Make sure to mark the boxes below before creating PR: [x]

- [x] Description above provides context of the change
- [x] Unit tests coverage for changes (not needed for documentation changes)
- [x] Target Github ISSUE in description if exists
- [x] Commits follow "[How to write a good git commit message](http://chris.beams.io/posts/git-commit/)"
- [x] Relevant documentation is updated including usage instructions.
- [x] I will engage committers as explained in [Contribution Workflow Example](https://github.com/apache/airflow/blob/master/CONTRIBUTING.rst#contribution-workflow-example).

---
In case of fundamental code change, Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvements+Proposals)) is needed.
In case of a new dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
In case of backwards incompatible changes please leave a note in [UPDATING.md](https://github.com/apache/airflow/blob/master/UPDATING.md).
Read the [Pull Request Guidelines](https://github.com/apache/airflow/blob/master/CONTRIBUTING.rst#pull-request-guidelines) for more information.
